### PR TITLE
Set autofocus to true on textbox

### DIFF
--- a/src/UiTextbox.vue
+++ b/src/UiTextbox.vue
@@ -129,7 +129,7 @@ export default {
         autocomplete: String,
         autofocus: {
             type: Boolean,
-            default: false
+            default: true
         },
         autosize: {
             type: Boolean,


### PR DESCRIPTION
Text box autofocus feature only works when we add the attribute "autofocus" to a input field hence its not necessarily required to set at false in "UiTextbox.vue". As a user I would only use autofocus on a input field if required by using the "autofocus" attribute.